### PR TITLE
Run Maven in batch mode in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,4 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Build with Maven
-        run: mvn verify
+        run: mvn verify -B


### PR DESCRIPTION
This ensures that the GitHub Actions task will not output Maven download progress and will shrink the logs substantially.