### PR TITLE
Upgrade bouncycastle from jdk15on to jdk18on

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <bcprov-jdk15on.version>1.70</bcprov-jdk15on.version>
+        <bcprov-jdk18on.version>1.77</bcprov-jdk18on.version>
         <build-helper-maven-plugin.version>3.5.0</build-helper-maven-plugin.version>
         <javers-core.version>7.3.7</javers-core.version>
         <spring-boot-dependencies-bom.version>3.1.8</spring-boot-dependencies-bom.version>
@@ -90,10 +90,11 @@
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
-            <version>${bcprov-jdk15on.version}</version>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>${bcprov-jdk18on.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Upgrade bouncycastle from jdk15on to jdk18on. Bouncy castle jdk15on has 1 vulnerability and hasn't been updated since 01 dec 2021