### PR TITLE
Use an Executor to execute a task

### DIFF
--- a/src/main/java/io/github/rabobank/shadow_tool/ShadowFlow.java
+++ b/src/main/java/io/github/rabobank/shadow_tool/ShadowFlow.java
@@ -270,7 +270,7 @@ public class ShadowFlow<T> {
          * @return This builder
          * @deprecated Use {@link #withExecutor(Executor) withExecutor} instead.
          */
-        @Deprecated
+        @Deprecated(since = "1.5.0", forRemoval = true)
         public ShadowFlowBuilder<T> withExecutorService(final ExecutorService executorService) {
             return withExecutor(executorService);
         }


### PR DESCRIPTION
Using an `Executor` gives the option to use more variants, such as a `SimpleAsyncTaskExecutor` where virtual threads are enabled.