### PR TITLE
docs: fix typos in Javadoc and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ The following differences were found: firstName, lastName. Encrypted values: 6U8
 ## Inspecting the values of differences
 
 Values are encrypted using the public key that is set up during the configuration.
-The default algorithm for Public Key encryption is RSA with Electronic Codeblock mode (CBC) and `OAEPWITHSHA-256ANDMGF1PADDING` padding.
+The default algorithm for Public Key encryption is RSA with Electronic Codebook mode (ECB) and `OAEPWITHSHA-256ANDMGF1PADDING` padding.
 
 ### Example of decrypting values of differences
 

--- a/src/main/java/io/github/rabobank/shadow_tool/NoopEncryptionService.java
+++ b/src/main/java/io/github/rabobank/shadow_tool/NoopEncryptionService.java
@@ -5,10 +5,10 @@ import org.bouncycastle.util.encoders.Base64;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
- * A version of the Encryption Service that doesn't perform any encryption,
- * it only encodes the differences as a Base 64 String.
+ * A version of the Encryption Service that doesn't perform any encryption.
+ * It only encodes the differences as a Base 64 String.
  * <p>
- * This might be useful for simple use-case where encryption of differences is not required,
+ * This might be useful for a simple use-case where encryption of differences is not required,
  * for example with public data.
  *
  * @see Base64#toBase64String(byte[])

--- a/src/main/java/io/github/rabobank/shadow_tool/ShadowFlow.java
+++ b/src/main/java/io/github/rabobank/shadow_tool/ShadowFlow.java
@@ -82,7 +82,7 @@ public class ShadowFlow<T> {
      *
      * @param currentFlow A supplier that returns the result of the service call
      *                    that you currently have.
-     * @param newFlow     A supplier that return the result of the new service call
+     * @param newFlow     A supplier that returns the result of the new service call
      *                    that you want to start using.
      * @return This will always return the value of currentFlow supplier.
      */
@@ -107,7 +107,7 @@ public class ShadowFlow<T> {
      *
      * @param currentFlow A supplier that returns the result of the service call
      *                    that you currently have.
-     * @param newFlow     A supplier that return the result of the new service call
+     * @param newFlow     A supplier that returns the result of the new service call
      *                    that you want to start using.
      * @param clazz       The model that the current and new flow should be mapped to for comparison.
      * @param <C>         The type of collection to compare, for example a List


### PR DESCRIPTION
## Summary

Documentation-only fixes: Javadoc comments and one README line. No code, no behaviour change.

### Findings from the report

- **NoopEncryptionService.java**: `This might be useful for simple use-case where ...` -> `for a simple use-case` (missing article)
- **NoopEncryptionService.java**: `... doesn't perform any encryption, it only encodes ...` -> `... doesn't perform any encryption. It only encodes ...` (comma splice; also gives the Javadoc a properly terminated first-sentence summary)

### Additional typos found while verifying (not in the original report)

- **ShadowFlow.java** (2 occurrences, lines 85 and 110): `@param newFlow     A supplier that return the result ...` -> `that returns`. The `@param currentFlow` line directly above each of them already reads `that returns`, and the two reactive overloads at lines 131/162 also read `that returns`, so these two were the odd ones out. Only the description text changed - the `@param` names themselves are untouched.
- **README.md** line 251: `RSA with Electronic Codeblock mode (CBC)` -> `RSA with Electronic Codebook mode (ECB)`. Two errors in one phrase: the expansion of ECB is "Electronic Codebook", and the abbreviation given was CBC, a different mode entirely. `PublicKeyEncryptionService.java` builds `RSA/ECB/OAEPWITHSHA-256ANDMGF1PADDING` and the `withEncryption` Javadoc says the same, so ECB is what the code actually uses.

Happy to split any of these out or drop them if you would rather keep the PR to the two Javadoc lines.